### PR TITLE
Improvement of the shdb params form

### DIFF
--- a/django_hatstall/identities/templates/shdb/shdb_form.html
+++ b/django_hatstall/identities/templates/shdb/shdb_form.html
@@ -14,7 +14,7 @@
   <form method="POST" action="">{% csrf_token %}
     <div class="form-group">
       <label for="shdb_user_form">User</label>
-      <input name="shdb_user_form"  class="form-control" id="shdb_user_form" placeholder="Username">
+      <input name="shdb_user_form"  class="form-control" id="shdb_user_form" placeholder="Username" required>
     </div>
     <div class="form-group">
       <label for="shdb_pass_form">Password</label>
@@ -22,11 +22,11 @@
     </div>
     <div class="form-group">
       <label for="shdb_name_form">Name</label>
-      <input name="shdb_name_form" class="form-control" id="shdb_name_form" placeholder="Name of the sh database">
+      <input name="shdb_name_form" class="form-control" id="shdb_name_form" placeholder="Name of the sh database" required>
     </div>
     <div class="form-group">
       <label for="shdb_host_form">Host</label>
-      <input name="shdb_host_form" class="form-control" id="shdb_host_form" placeholder="Host of the sh database">
+      <input name="shdb_host_form" class="form-control" id="shdb_host_form" placeholder="Host of the sh database" required>
     </div>
     <button type="submit" class="btn btn-primary">Connect</button>
   </form>

--- a/django_hatstall/identities/views.py
+++ b/django_hatstall/identities/views.py
@@ -190,7 +190,12 @@ def get_shdb_params(request, err=None):
         shdb_pass = request.POST.get('shdb_pass_form')
         shdb_name = request.POST.get('shdb_name_form')
         shdb_host = request.POST.get('shdb_host_form')
-    if shdb_user and shdb_name and shdb_host:
+        try:
+            db = sortinghat_db_conn()
+        except sortinghat.exceptions.DatabaseError as error:
+            err = error
+
+    if shdb_user and shdb_name and shdb_host and not err:
         return redirect('/profiles/list')
     context = {
         "err": err


### PR DESCRIPTION
Refering to #11 , PR adds:

- When a param of the form is incorrect, the app crashes. Now just redirect you to the same page deleting the values of the form and showing a "error" message at the top of the page.

- All inputs of the form (except password) are now required fields, in order to avoid errors.